### PR TITLE
Run cover report only when it's not a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
   - go get github.com/mattn/goveralls
 
 script:
-  - go test -v -covermode=count -coverprofile=coverage.out && $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then go test -v -cover; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then go test -v -covermode=count -coverprofile=coverage.out && $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN; fi'
 
 notifications:
   email:


### PR DESCRIPTION
According to the travis documentation [1] encrypted environment variables are
not available to pull requests from forks due to the security risk of exposing
such information to unknown code.

To solve this we will add a condition in the Travis script, as described in the
Travis documentation [2].

This problem was detected in #11.

[1] https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml
[2] https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions